### PR TITLE
新增前端端口偏移功能

### DIFF
--- a/app/Utils/URL.php
+++ b/app/Utils/URL.php
@@ -298,7 +298,18 @@ class URL
                     ->orWhere("user_id", "=", 0);
             }
         )->first();
-        $node_name = $node->name;
+        /***节点名字后加#偏移值***/
+        $temp = explode("#", $node->name);
+        $offset = 0;
+        if ($temp[1]!=null){
+            $node_name = $temp[0];
+            if (is_numeric($temp[1])) {
+                $offset = $temp[1];
+            }
+        } else {
+            $node_name = $node->name;
+        }
+        /************/
         if ($relay_rule != null) {
             $node_name .= " - ".$relay_rule->dist_node()->name;
         }
@@ -324,7 +335,8 @@ class URL
             $user = URL::getSSRConnectInfo($user);
         }
         $return_array['address'] = $node->server;
-        $return_array['port'] = $user->port;
+        /***端口偏移***/
+        $return_array['port'] = $user->port+$offset;
         $return_array['passwd'] = $user->passwd;
         $return_array['method'] = $user->method;
         $return_array['remark'] = $node_name;


### PR DESCRIPTION
使用方法：
 - 节点名字后加#偏移值
 - 如用户端口为1025，节点名称为节点1，则端口为1025；节点名称为节点2#1000，则端口为2025；节点名称为节点3#-1000，则端口为25